### PR TITLE
Added a help command

### DIFF
--- a/lib/tasks/help.ex
+++ b/lib/tasks/help.ex
@@ -1,0 +1,51 @@
+defmodule Mix.Tasks.Workshop.Help do
+  use Mix.Task
+  alias IO.ANSI.Docs
+
+  @spec run(OptionParser.argv) :: :ok
+  def run(argv) do
+    Workshop.start([], [])
+    {opts, _, _} = OptionParser.parse(argv, switches: [system: :boolean])
+    title = Workshop.Info.get(Workshop.Meta, :title)
+    version = Workshop.Info.get(Workshop.Meta, :version)
+
+    help = cond do
+      Workshop.Info.get(Workshop.Meta, :home) == nil ->
+        nil
+      String.starts_with?(Workshop.Info.get(Workshop.Meta, :home), "https://github.com/") ->
+        """
+        If something is unclear or you need further help you could try
+        browsing the already asked questions in the GitHub issues for this
+        workshop:
+
+          * #{Workshop.Info.get(Workshop.Meta, :home)}/issues
+        """
+      home = Workshop.Info.get(Workshop.Meta, :home) ->
+        """
+        Visit *#{home}* for more information about this workshop.
+        """
+    end
+
+    Docs.print_heading "#{title} v#{version} - Help", opts
+    Docs.print """
+    Please make sure that your system is ready for the workshop by using
+    the `mix workshop.doctor` command. Also, the `mix workshop.validate`
+    command can tell you if the workshop itself is ready for running.
+
+    Your progress can be displayed by simply typing `mix workshop` in the
+    terminal.
+
+    The exercise description of the current exercise can be displayed using
+    the `mix workshop.info` command, and the solution can be verified with
+    the `mix workshop.verify` command.
+
+    If a solution is valid the `mix workshop.next` command can be used to
+    checkout and progress to the next exercise.
+
+    If you are stuck in an exercise you could try the `mix workshop.hint`
+    command, which will give you a hint about completing the exercise.
+
+    #{help}
+    """, opts
+  end
+end

--- a/lib/tasks/new/workshop.ex
+++ b/lib/tasks/new/workshop.ex
@@ -84,6 +84,13 @@ defmodule Mix.Tasks.New.Workshop do
     # is running.
     @version "0.0.1"
 
+    # An optional url to the website of the workshop. If the website is a Git repo
+    # on GitHub the help page will point to the GitHub issues page when the user
+    # types `mix workshop.help`
+    #
+    # ie: `https://github.com/foo/bar` becomes `https://github.com/foo/bar/issues`
+    @home nil
+
     # An optional short description of the workshop. Will get shown at places
     # where the long description would not fit, such as the `mix workshop` screen.
     # Set this to `false` if you want to suppress the missing shortdesc warning.

--- a/lib/workshop/info.ex
+++ b/lib/workshop/info.ex
@@ -4,7 +4,7 @@ defmodule Workshop.Info do
   @doc false
   defmacro __using__(_opts) do
     quote do
-      Enum.each [:title, :version, :description, :shortdesc, :introduction, :debriefing],
+      Enum.each [:title, :version, :home, :description, :shortdesc, :introduction, :debriefing],
         &Module.register_attribute(__MODULE__, &1, persist: true)
     end
   end


### PR DESCRIPTION
- It display information on the usage of the workshop software
- Added an optional `@home` module attribute to the _workshop.exs_ file; here the workshop creator can define a website with more information about the workshop.
  
  If the `@home` starts with _https://github.com_ the the help screen will display a link to the github issues of the repo informing the user that questions can be asked there.
- Updated the `new.workshop` template to include the @home attribute in the generated _workshop.exs_ file
