### PR TITLE
Weights as module attributes

### DIFF
--- a/lib/tasks/hint.ex
+++ b/lib/tasks/hint.ex
@@ -19,7 +19,7 @@ defmodule Mix.Tasks.Workshop.Hint do
       exercise_identifier = Exercise.get_identifier(exercise_module)
       hints_given = Workshop.State.get(:exercises)[exercise_identifier][:hint]
       displayed_hints = hints |> Enum.take(hints_given) |> Enum.map_reduce(1, fn hint, acc ->
-        {"#{acc}. #{hint}", acc + 1}
+        {"#{acc}. #{String.rstrip(hint)}\n", acc + 1}
       end) |> elem(0)
 
       help = cond do

--- a/lib/tasks/workshop.ex
+++ b/lib/tasks/workshop.ex
@@ -32,9 +32,9 @@ defmodule Mix.Tasks.Workshop do
     current_exercise = Workshop.Session.get(:current_exercise)
     progress = Workshop.State.get(:exercises, [])
 
-    Exercises.list!
+    Exercises.list_by_weight!
     |> Enum.with_index
-    |> Enum.map(fn {exercise, index} ->
+    |> Enum.map(fn {{_weight, exercise}, index} ->
          module = Exercise.load(exercise)
          %{number: index + 1,
            title: Exercise.get(module, :title),

--- a/lib/workshop/exercises.ex
+++ b/lib/workshop/exercises.ex
@@ -26,23 +26,24 @@ defmodule Workshop.Exercises do
   @spec list_by_weight!() :: [{Integer, String.t}]
   def list_by_weight! do
     list!
-    |> Enum.map(&Exercise.split_weight_and_name/1)
+    |> Enum.map(&Exercise.weight_and_name/1)
     |> Enum.sort
   end
 
   @spec list_by_weight!(String.t) :: [{Integer, String.t}]
   def list_by_weight!(folder) do
     list!(folder)
-    |> Enum.map(&Exercise.split_weight_and_name/1)
+    |> Enum.map(&Exercise.weight_and_name/1)
     |> Enum.sort
   end
 
   @doc """
   Will convert `name` to `weight_name` given a list of names and exercises
   """
-  @spec get_weights_from_name([String.t], [String.t]) :: {Integer, String.t}
+  @spec get_weights_from_name([String.t], [String.t]) :: [{Integer, String.t}]
+  def get_weights_from_name([], _), do: []
   def get_weights_from_name(exercises, exercise_list) do
-    weights = Enum.map(exercise_list, &Exercise.split_weight_and_name/1)
+    weights = Enum.map(exercise_list, &Exercise.weight_and_name/1)
               |> Enum.into(%{}, fn {weight, name} -> {name, weight} end)
 
     Enum.map(exercises, fn exercise ->


### PR DESCRIPTION
- New exercises are now created with @weights-attrs
- It will now write to workshop state when it is done copying files from source to sandbox.
- It can now check for passing state on exercises that has are not in state file (it will just return false)
- It does not rely on the name to weight+name mapping
- Expect exercise folders in sandbox to start with digits and an underscore
- Expect exercise folders in source to be have a valid exercises folder name, as specified in `Exercise.valid_name?`
- Exercises, when listed, are now sorted using the weight defined in the _exercise.exs_-file
- It should find the correct current exercise directory when initialising from the sandbox, if there is one
- Hints should now display even if the state is already defined
