### PR TITLE
Added a `mix workshop.version` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Perform a system integrity check. It will fail the test if prerequisites, such a
 
 I.e. a workshop that require a specific database to be installed could have a test that fails if the user does not have that database installed.
 
+### `mix workshop.version`
+Will print the version number of the current exercise. This is mostly for troubleshooting reasons, and to make sure every student at a seminar is running the same version of the workshop.
+
 ### `mix workshop.help`
 Describe the workshop command to the user, and if a *home* link is set for the workshop it will get displayed on this screen.
 

--- a/lib/tasks/version.ex
+++ b/lib/tasks/version.ex
@@ -1,0 +1,14 @@
+defmodule Mix.Tasks.Workshop.Version do
+  use Mix.Task
+
+  @spec run(OptionParser.argv) :: :ok
+  def run(argv) do
+    Workshop.start([], [])
+    {_opts, _, _} = OptionParser.parse(argv, switches: [])
+
+    title = Workshop.Info.get(Workshop.Meta, :title)
+    version = Workshop.Info.get(Workshop.Meta, :version)
+
+    Mix.shell.info "#{title} v#{version}"
+  end
+end


### PR DESCRIPTION
- Added a `mix workshop.version` command.
- Print the version number it find in the current workshop _workshop.exs_ file.
- This would be used in classes where the instructor would like to ensure that the students are running the same version of a given workshop.
