### PR TITLE
Verify exercise solutions with test scrips

### DIFF
--- a/lib/tasks/check.ex
+++ b/lib/tasks/check.ex
@@ -1,26 +1,50 @@
 defmodule Mix.Tasks.Workshop.Check do
   use Mix.Task
+
   alias Workshop.Exercise
+  alias Workshop.Session
+  alias Workshop.ValidationResult, as: Result
+
   @spec run(OptionParser.argv) :: :ok
   def run(argv) do
     Workshop.start([], [])
     {_opts, _, _} = OptionParser.parse(argv, switches: [system: :boolean])
 
-    current_exercise = Workshop.Session.get(:current_exercise)
+    current_exercise = Session.get(:current_exercise)
     if current_exercise do
-      exercise = Exercise.load current_exercise
-      exercises_state = Workshop.State.get(:exercises, [])
-      identifier = Exercise.get_identifier(exercise)
+      exercise_folder = current_exercise |> Path.expand(Session.get(:exercises_folder))
+      test_helper = "test/test_helper.exs" |> Path.expand(exercise_folder)
 
-      current_exercise_state = exercises_state[identifier] || []
-      new_state = Keyword.put(current_exercise_state, :status, :completed)
+      [{module, _}| _] = Code.require_file(test_helper)
 
-      Workshop.State.update(:exercises, Keyword.put(exercises_state, identifier, new_state))
-      Workshop.State.persist!
-
-      Mix.shell.info "Marked as completed!"
+      module.exec(current_exercise)
+      |> handle_result
     else
       Mix.shell.info "This command should get executed from within an exercise folder"
+    end
+  end
+
+  defp handle_result(%Result{errors: [], warnings: []}) do
+    Session.get(:current_exercise) |> Exercise.set_status(:completed)
+
+    Mix.shell.info """
+    All good! Type `mix workshop.next` to progress to next exercise
+    """
+  end
+
+  defp handle_result(%Result{} = result) do
+    Session.get(:current_exercise) |> Exercise.set_status(:in_progress)
+
+    messages = Enum.map(result.errors, &("Error: #{&1}")) ++ Enum.map(result.warnings, &("Warning: #{&1}"))
+    Mix.shell.error """
+    The current solution did not pass the acceptance test for the following reasons:
+
+    #{messages |> Enum.map(&("  * #{&1}")) |> Enum.join("\n")}
+
+    Try the `mix workshop.hint` or `mix workshop.help` commands if you are stuck.
+    """
+    System.at_exit fn _ ->
+      exit({:shutdown, 1})
     end
   end
 end

--- a/lib/tasks/new/exercise.ex
+++ b/lib/tasks/new/exercise.ex
@@ -91,7 +91,8 @@ defmodule Mix.Tasks.New.Exercise do
     create_directory "files"
     create_directory "solution"
     create_directory "test"
-    create_file "test/test_helper.exs", ""
+    create_file "test/test_helper.exs", test_helper_template(assigns)
+    create_file "test/check.exs", check_template(assigns)
   end
 
   embed_template :exercise, """
@@ -118,6 +119,42 @@ defmodule Mix.Tasks.New.Exercise do
       @todo, write a couple of hints for the solving this exercise
       \"""
     ]
+  end
+  """
+
+  embed_template :test_helper, """
+  defmodule Workshop.Exercise.<%= @module %>Check.Helper do
+    def exec(solution) do
+      # this file should know how to load the given exercise solution
+      solution_dir =
+        solution
+        |> Workshop.Exercise.exercise_sandbox_name
+        |> Path.expand(Workshop.Session.get(:folder))
+
+      # locate and load the users solution
+      script = "exercise.exs" |> Path.expand(solution_dir)
+      Code.require_file(script)
+
+      # load and run the solution checker
+      Code.require_file("check.exs", __DIR__)
+
+      Workshop.Exercise.<%= @module %>Check.run()
+    end
+  end
+  """
+
+  embed_template :check, """
+  defmodule Workshop.Exercise.<%= @module %>Check do
+    use Workshop.SolutionCheck
+
+    verify "verify something" do
+      # return value can be :ok, {:warning, message}, or {:error, message}
+      :ok
+    end
+
+    verify "verify something else" do
+      :ok
+    end
   end
   """
 end

--- a/lib/workshop/exercise.ex
+++ b/lib/workshop/exercise.ex
@@ -188,4 +188,15 @@ defmodule Workshop.Exercise do
       false
     end
   end
+
+  @spec set_status(String.t, Atom) :: :ok
+  def set_status(exercise, new_status) do
+    identifier = load(exercise) |> get_identifier
+    exercises_state = Workshop.State.get(:exercises, [])
+    current_exercise_state = exercises_state[identifier] || []
+    new_state = Keyword.put(current_exercise_state, :status, new_status)
+
+    Workshop.State.update(:exercises, Keyword.put(exercises_state, identifier, new_state))
+    Workshop.State.persist!
+  end
 end

--- a/lib/workshop/solution_check.ex
+++ b/lib/workshop/solution_check.ex
@@ -1,0 +1,33 @@
+defmodule Workshop.SolutionCheck do
+  defmacro __using__(_opts) do
+    quote do
+      import unquote(__MODULE__)
+      Module.register_attribute __MODULE__, :checks, accumulate: true
+      @before_compile unquote(__MODULE__)
+    end
+  end
+
+  defmacro __before_compile__(_env) do
+    quote do
+      def run, do: Workshop.SolutionCheck.Test.run(@checks, __MODULE__)
+    end
+  end
+
+  defmacro verify(description, do: verify_block) do
+    verify_func = String.to_atom(description)
+    quote do
+      @checks {unquote(verify_func), unquote(description)}
+      def unquote(verify_func)(), do: unquote(verify_block)
+    end
+  end
+end
+
+defmodule Workshop.SolutionCheck.Test do
+  alias Workshop.ValidationResult, as: Result
+
+  def run(checks, module) do
+    for {func, _description} <- checks, into: %Result{} do
+      apply(module, func, [])
+    end
+  end
+end


### PR DESCRIPTION
Not sure this solution is the final--there are definitely room for improvement.
- Unit test like system for writing acceptance tests
- The results will be put into a ValidationResults struct
- If the checks pass the status of the exercise will get set to `:completed`, and `:in_progress` if it fails
- The `Workshop.Exercise`-module has a helper function for updating the state of a given exercise.
- The new exercise template create the content for the _test_helper.exs_ file, which bootstrap the verifyer, and create _check.exs_ file that contain some dummy checks.
