### PR TITLE
Callback functionality

### DIFF
--- a/lib/tasks/check.ex
+++ b/lib/tasks/check.ex
@@ -32,11 +32,10 @@ defmodule Mix.Tasks.Workshop.Check do
   # when checking user solution
   defp handle_result(%Result{errors: [], warnings: []}) do
     exercise = Session.get(:current_exercise)
-    exercise_module = Exercise.load(exercise)
-    identifier = Exercise.get_identifier(exercise_module)
 
-    unless Workshop.State.get(:exercises)[identifier][:status] == :completed do
-      # run exercise completed callback when transitioning into completed state
+    unless Exercise.get_status(exercise) == :completed do
+      # run `exercise completed` callback when transitioning into completed state
+      exercise_module = Exercise.load(exercise)
       Exercise.run_callback(exercise_module, :on_exercise_completed)
     end
 

--- a/lib/tasks/check.ex
+++ b/lib/tasks/check.ex
@@ -31,7 +31,16 @@ defmodule Mix.Tasks.Workshop.Check do
 
   # when checking user solution
   defp handle_result(%Result{errors: [], warnings: []}) do
-    Session.get(:current_exercise) |> Exercise.set_status(:completed)
+    exercise = Session.get(:current_exercise)
+    exercise_module = Exercise.load(exercise)
+    identifier = Exercise.get_identifier(exercise_module)
+
+    unless Workshop.State.get(:exercises)[identifier][:status] == :completed do
+      # run exercise completed callback when transitioning into completed state
+      Exercise.run_callback(exercise_module, :on_exercise_completed)
+    end
+
+    Exercise.set_status(exercise, :completed)
 
     Mix.shell.info """
     All good! Type `mix workshop.next` to progress to next exercise

--- a/lib/workshop/exercise.ex
+++ b/lib/workshop/exercise.ex
@@ -247,7 +247,18 @@ defmodule Workshop.Exercise do
   end
 
   @doc """
-  Update the state of the given exercise with the given state.
+  Get the status of the given exercise
+  """
+  @spec get_status(String.t) :: :in_progress | :completed | nil
+  def get_status(exercise) do
+    identifier = load(exercise) |> get_identifier
+    exercises_state = State.get(:exercises, [])
+    current_exercise_state = exercises_state[identifier] || []
+    current_exercise_state[:status]
+  end
+
+  @doc """
+  Update the status of the given exercise with new status.
   """
   @spec set_status(String.t, Atom) :: :ok
   def set_status(exercise, new_status) do

--- a/lib/workshop/exercise.ex
+++ b/lib/workshop/exercise.ex
@@ -259,4 +259,20 @@ defmodule Workshop.Exercise do
     State.update(:exercises, Keyword.put(exercises_state, identifier, new_state))
     State.persist!
   end
+
+  @doc """
+  Helper for running callbacks at certain points in the exercise work flow.
+
+  The function expect a exercise module, the function which should get called, defined
+  as a public function on the exercise module, and the arguments that the function
+  should get called with.
+
+  It will figure the arity of the callback function from the size of the args list.
+  """
+  @spec run_callback(Atom, Atom, [Any]) :: Any
+  def run_callback(exercise_module, callback, args \\ []) do
+    if Code.ensure_loaded?(exercise_module) and function_exported?(exercise_module, callback, length args) do
+      apply(exercise_module, callback, args)
+    end
+  end
 end


### PR DESCRIPTION
- Implemented `run_callback/3` (and `run_callback/2`) function that
  can be used to define callback hooks that will get run at given
  points in the workshop flow
- If the exercise module defines a public function
  `on_exercise_completed/0` it will get run when the student completes
  the current exercise.
- The callback hooks are optional, if they are not defined they will
  not get run.
