### PR TITLE
Mention correct verify/check command

### DIFF
--- a/lib/tasks/help.ex
+++ b/lib/tasks/help.ex
@@ -37,7 +37,7 @@ defmodule Mix.Tasks.Workshop.Help do
 
     The exercise description of the current exercise can be displayed using
     the `mix workshop.info` command, and the solution can be verified with
-    the `mix workshop.verify` command.
+    the `mix workshop.check` command.
 
     If a solution is valid the `mix workshop.next` command can be used to
     checkout and progress to the next exercise.


### PR DESCRIPTION
Seems like the help text mentions a non-existing mix task.

_Side note:_
I sometimes feel confused by the usage of verify/validate. The first is meant for students, the second for the teacher/creator of workshop. I feel there should be a more clear distinction between the 2 personas. If I come across a place where that can be improved, I'll let you know ;)
