### PR TITLE
Mention next steps after initiating workshop.next

### DIFF
--- a/lib/tasks/next.ex
+++ b/lib/tasks/next.ex
@@ -26,7 +26,11 @@ defmodule Mix.Tasks.Workshop.Next do
         case Workshop.Exercise.copy_files_to_sandbox(exercise) do
           :ok ->
             Mix.shell.info """
-            Go ahead and work in #{exercise}
+            Go ahead and work in #{exercise}.
+
+            Type `mix workshop.info` and `mix workshop.task` from the new
+            folder to get the description and task of your next exercise.
+            Have fun!
             """
 
           {:exists, folder} ->


### PR DESCRIPTION
During the first workshop I did, I had to specifically mention `workshop.task` a
few times. I think it's nice to mention `mix workshop.info` + `.task` so people have a
better clue about what to do next.
